### PR TITLE
Update minor number

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,6 @@
 7.0.0 (2013-06-19):
 * Initial public release
+
+7.1.0 (2013-07-03):
+* Update minor number to disambiguate new builds from builds of the
+  old mercurial repo.

--- a/build.py
+++ b/build.py
@@ -267,7 +267,7 @@ if __name__ == '__main__':
     debug = { 'checked': True, 'free': False }
 
     os.environ['MAJOR_VERSION'] = '7'
-    os.environ['MINOR_VERSION'] = '0'
+    os.environ['MINOR_VERSION'] = '1'
     os.environ['MICRO_VERSION'] = '0'
 
     if 'BUILD_NUMBER' not in os.environ.keys():


### PR DESCRIPTION
When the repo was moved from mercurial to git the build system started
build numbers from #1 again. Bump the minor version number to avoid
confusion between these new builds and old builds of the original repo.

Signed-off-by: Owen Smith owen.smith@citrix.com
