### PR TITLE
[CA-134598] Store the (partial) tag along with the XENVBD_REQUEST.

### DIFF
--- a/src/xenvbd/pdo.h
+++ b/src/xenvbd/pdo.h
@@ -190,7 +190,7 @@ PdoSubmitPrepared(
 extern VOID
 PdoCompleteSubmitted(
     __in PXENVBD_PDO             Pdo,
-    __in PXENVBD_REQUEST         Request,
+    __in ULONG                   Tag,
     __in SHORT                   Status
     );
 

--- a/src/xenvbd/srbext.h
+++ b/src/xenvbd/srbext.h
@@ -82,6 +82,7 @@ typedef struct _XENVBD_REQUEST_INDIRECT {
 typedef struct _XENVBD_REQUEST {
     PSCSI_REQUEST_BLOCK Srb;
     LIST_ENTRY          Entry;
+    ULONG               Id; // atomically increasing number
 
     UCHAR               Operation;
     union _XENVBD_REQUEST_TYPE {


### PR DESCRIPTION
Migrate and a bus/target reset will re-queue any existing inflight requests, but not
reset the request tagging correctly, and will eventually run out of free tags.

Signed-off-by: Owen Smith owen.smith@citrix.com
