### PR TITLE
Coinstaller disk timeout

### DIFF
--- a/src/coinst/coinst.c
+++ b/src/coinst/coinst.c
@@ -345,7 +345,7 @@ IncreaseDiskTimeout(
     HRESULT     Error;
 
     Error = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
-                         SERVICE_KEY("Disk"),
+                         SERVICE_KEY(Disk),
                          0,
                          KEY_ALL_ACCESS,
                          &Key);


### PR DESCRIPTION
Up the disk timeout to at least 2 minutes, to match what tapdisk uses as an internal timeout. This value was previously set with the legacy tools installer.
